### PR TITLE
Bugfix package name (symlinking)

### DIFF
--- a/Command/TinymceSymlinkCommand.php
+++ b/Command/TinymceSymlinkCommand.php
@@ -19,7 +19,7 @@ use Mopa\Bridge\Composer\Util\ComposerPathFinder;
  */
 class TinymceSymlinkCommand extends ContainerAwareCommand
 {
-    public static $stfalconTinymceBundleName = "stfalcon/tinymce-bundle";
+    public static $stfalconTinymceBundleName = "gibilogic/tinymce-bundle";
     public static $tinymceName = "tinymce/tinymce";
     public static $targetSuffix = '';
     public static $pathName = 'Tinymce';


### PR DESCRIPTION
I changed the composer bundle name in the Tinymce Symlink command to:

gibilogic/tinymce-bundle
