### PR TITLE
configuration cannot be merge and must replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ You can also override the default configuration by passing an option like this:
     {{ tinymce_init({'use_callback_tinymce_init': true, 'theme': {'simple': {'menubar': false}}}) }}
 ```
 
+This function allow a second parameter that let you chose if the given configuration must replace the orignal configuration or be merged it. `True` will replace, `False` will merge (default: `false`).
+
+
 ## Base configuration
 
 By default, tinymce is enabled for all textareas on the page. If you want to customize it, do the following:

--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -78,10 +78,14 @@ class StfalconTinymceExtension extends \Twig_Extension
      * @param array $options
      * @return string
      */
-    public function tinymceInit($options = array())
+    public function tinymceInit($options = array(), $replace = false)
     {
         $config = $this->getParameter('stfalcon_tinymce.config');
-        $config = array_replace_recursive($config, $options);
+        if ($replace) {
+            $config = array_replace_recursive($config, $options);
+        } else {
+            $config = array_merge_recursive($config, $options);
+        }
 
         $this->baseUrl = (!isset($config['base_url']) ? null : $config['base_url']);
         /** @var $assets \Symfony\Component\Templating\Helper\CoreAssetsHelper */

--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -81,7 +81,7 @@ class StfalconTinymceExtension extends \Twig_Extension
     public function tinymceInit($options = array())
     {
         $config = $this->getParameter('stfalcon_tinymce.config');
-        $config = array_merge_recursive($config, $options);
+        $config = array_replace_recursive($config, $options);
 
         $this->baseUrl = (!isset($config['base_url']) ? null : $config['base_url']);
         /** @var $assets \Symfony\Component\Templating\Helper\CoreAssetsHelper */


### PR DESCRIPTION
Merge options with array_merge_recursive lead to unusable configuration. For example, if we overwrite `tinymce_jquery` the resulting value is `tinymce_jquery: [true, false]` witch is a non-sense.
