### PR TITLE
separation of assets loading and editor instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,14 @@ If you want to use jQuery version of the editor set the following parameters:
 
 ```yaml
     stfalcon_tinymce:
+        include_assets: true
         include_jquery: true
         tinymce_jquery: true
         ...
 ```
+
+The option `include_assets` allows you to controle if assets (jQuery and TinyMCE)
+must be loaded. Set it to `false` if you include theme already by yourself.
 
 The option `include_jquery` allows you to load external jQuery library from the Google CDN. Set it to `true` if you haven't included jQuery on your page.
 

--- a/Resources/views/Script/assets.html.twig
+++ b/Resources/views/Script/assets.html.twig
@@ -1,0 +1,11 @@
+{% if include_jquery %}
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.11.1.min.js"></script>
+{% endif %}
+{% if tinymce_jquery %}
+    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/vendor/tinymce/jquery.tinymce.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/js/init.jquery.js') }}"></script>
+{% else %}
+    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/vendor/tinymce/tinymce.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/js/ready.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/js/init.standard.js') }}"></script>
+{% endif %}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,6 +24,8 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder
             ->root('stfalcon_tinymce', 'array')
                 ->children()
+                    // Include assets (jquery, TinyMCE)
+                    ->booleanNode('include_assets')->defaultTrue()->end()
                     // Include jQuery (true) library or not (false)
                     ->booleanNode('include_jquery')->defaultFalse()->end()
                     // Use jQuery (true) or standalone (false) build of the TinyMCE

--- a/src/Resources/views/Script/init.html.twig
+++ b/src/Resources/views/Script/init.html.twig
@@ -1,14 +1,4 @@
-{% if include_jquery %}
-    <script type="text/javascript" src="//code.jquery.com/jquery-1.11.1.min.js"></script>
-{% endif %}
-{% if tinymce_jquery %}
-    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/vendor/tinymce/jquery.tinymce.min.js') }}"></script>
-    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/js/init.jquery.js') }}"></script>
-{% else %}
-    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/vendor/tinymce/tinymce.min.js') }}"></script>
-    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/js/ready.min.js') }}"></script>
-    <script type="text/javascript" src="{{ asset(base_url~'bundles/stfalcontinymce/js/init.standard.js') }}"></script>
-{% endif %}
+{{tinymce_assets()}}
 <script type="text/javascript">
 //<![CDATA[
     stfalcon_tinymce_config = {{ tinymce_config|raw }};


### PR DESCRIPTION
This PR allow to load separately assets and TinyMCE instantiation. This allow for example the possibility to load assets only once if we have 2 editors on the same page.
