### PR TITLE
Changed short open tag to long version

### DIFF
--- a/src/Command/SymlinkCommand.php
+++ b/src/Command/SymlinkCommand.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace Stfalcon\Bundle\TinymceBundle\Command;
 


### PR DESCRIPTION
Try to avoid short open tags. Default php configurations disables this function!
