### PR TITLE
Use assets.packages if available

### DIFF
--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -211,6 +211,9 @@ class StfalconTinymceExtension extends \Twig_Extension
 
     protected function getUrl($url)
     {
+        if ($this->container->has('assets.packages')) {
+            return $this->container->get('assets.packages')->getUrl($url);
+        }
         if ($this->container->has('templating.helper.assets')) {
             return $this->container->get('templating.helper.assets')->getUrl($url);
         }


### PR DESCRIPTION
This is a follow up to #17 to use `assets.packages` directly if available (SF >=2.7).
From that version the `templating.helper.assets` internally uses that service anyway, before the assets implementation was in the templating component.
