### PR TITLE
[WIP] one open parameter for TinyMCE configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This bundle comes with an extension for Twig. This makes it very easy to include
 You can also override the default configuration by passing an option like this:
 
 ```twig
-    {{ tinymce_init({'use_callback_tinymce_init': true, 'theme': {'simple': {'menubar': false}}}) }}
+    {{ tinymce_init({'use_callback_tinymce_init': true, tinymce_config:{'theme': {'simple': {'menubar': false}}}}) }}
 ```
 
 This function allow a second parameter that let you chose if the given configuration must replace the orignal configuration or be merged it. `True` will replace, `False` will merge (default: `false`).
@@ -109,12 +109,13 @@ You can change the language of your TinyMCE editor by adding language selector i
     stfalcon_tinymce:
         include_jquery: true
         tinymce_jquery: true
-        selector: ".tinymce"
-        language: %locale%
-        theme:
-            simple:
-                theme: "modern"
-        ...
+        tinymce_config:
+            selector: ".tinymce"
+            language: %locale%
+            theme:
+                simple:
+                    theme: "modern"
+            ...
 
 ```
 
@@ -133,37 +134,40 @@ According to the TinyMCE documentation you can configure your editor as you wish
     stfalcon_tinymce:
         include_jquery: true
         tinymce_jquery: true
-        selector: ".tinymce"
-        base_url: "http://yourdomain.com/" # this parameter may be included if you need to override the assets_base_urls for your template engine (to override a CDN base url)
-        # Get current language from the parameters.ini
-        language: %locale%
-        # Custom buttons
-        tinymce_buttons:
-            stfalcon: # Id of the first button
-                title: "Stfalcon"
-                image: "http://stfalcon.com/favicon.ico"
-        theme:
-            # Simple theme: same as default theme
-            simple: ~
-            # Advanced theme with almost all enabled plugins
-            advanced:
-                 plugins:
-                     - "advlist autolink lists link image charmap print preview hr anchor pagebreak"
-                     - "searchreplace wordcount visualblocks visualchars code fullscreen"
-                     - "insertdatetime media nonbreaking save table contextmenu directionality"
-                     - "emoticons template paste textcolor"
-                 toolbar1: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
-                 toolbar2: "print preview media | forecolor backcolor emoticons | stfalcon | example"
-                 image_advtab: true
-                 templates:
-                     - {title: 'Test template 1', content: 'Test 1'}
-                     - {title: 'Test template 2', content: 'Test 2'}
-            # BBCode tag compatible theme (see http://www.bbcode.org/reference.php)
-            bbcode:
-                 plugins: ["bbcode, code, link, preview"]
-                 menubar: false
-                 toolbar1: "bold,italic,underline,undo,redo,link,unlink,removeformat,cleanup,code,preview"
+        tinymce_config:
+            selector: ".tinymce"
+            base_url: "http://yourdomain.com/" # this parameter may be included if you need to override the assets_base_urls for your template engine (to override a CDN base url)
+            # Get current language from the parameters.ini
+            language: %locale%
+            # Custom buttons
+            tinymce_buttons:
+                stfalcon: # Id of the first button
+                    title: "Stfalcon"
+                    image: "http://stfalcon.com/favicon.ico"
+            theme:
+                # Simple theme: same as default theme
+                simple: ~
+                # Advanced theme with almost all enabled plugins
+                advanced:
+                     plugins:
+                         - "advlist autolink lists link image charmap print preview hr anchor pagebreak"
+                         - "searchreplace wordcount visualblocks visualchars code fullscreen"
+                         - "insertdatetime media nonbreaking save table contextmenu directionality"
+                         - "emoticons template paste textcolor"
+                     toolbar1: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
+                     toolbar2: "print preview media | forecolor backcolor emoticons | stfalcon | example"
+                     image_advtab: true
+                     templates:
+                         - {title: 'Test template 1', content: 'Test 1'}
+                         - {title: 'Test template 2', content: 'Test 2'}
+                # BBCode tag compatible theme (see http://www.bbcode.org/reference.php)
+                bbcode:
+                     plugins: ["bbcode, code, link, preview"]
+                     menubar: false
+                     toolbar1: "bold,italic,underline,undo,redo,link,unlink,removeformat,cleanup,code,preview"
 ```
+
+> NOTE! All the options set in `tinymce_config` are passed _as-is_ to TinyMCE. So there is no restriction to set some TinyMCE custom config parameter.
 
 ### External plugins support
 
@@ -171,16 +175,17 @@ If you want to load some external plugins which are situated in your bundle, you
 
 ```yaml
     stfalcon_tinymce:
-        external_plugins:
-            filemanager:
-                url: "asset[bundles/acmedemo/js/tinymce-plugin/filemanager/editor_plugin.js]"
-            imagemanager:
-                url: "asset[bundles/acmedemo/js/tinymce-plugin/imagemanager/editor_plugin.js]"
-        ...
-        theme:
-            simple:
-                theme: "modern"
-                ...
+        tinymce_config:
+            external_plugins:
+                filemanager:
+                    url: "asset[bundles/acmedemo/js/tinymce-plugin/filemanager/editor_plugin.js]"
+                imagemanager:
+                    url: "asset[bundles/acmedemo/js/tinymce-plugin/imagemanager/editor_plugin.js]"
+            ...
+            theme:
+                simple:
+                    theme: "modern"
+                    ...
 ```
 
 ### Custom buttons
@@ -191,23 +196,24 @@ First of all you should describe it in your config:
 
 ```yaml
     stfalcon_tinymce:
-        tinymce_buttons:
-            stfalcon: # Id of the first button
-                title: "Stfalcon"
-                image: "http://stfalcon.com/favicon.ico"
-            hello_world: # Id of the second button
-                title: "Google"
-                image: "http://google.com/favicon.ico"
-                ...
-                or for the local images
-                ...
-                image: "asset[bundles/somebundle/images/icon.ico]"
+        tinymce_config:
+            tinymce_buttons:
+                stfalcon: # Id of the first button
+                    title: "Stfalcon"
+                    image: "http://stfalcon.com/favicon.ico"
+                hello_world: # Id of the second button
+                    title: "Google"
+                    image: "http://google.com/favicon.ico"
+                    ...
+                    or for the local images
+                    ...
+                    image: "asset[bundles/somebundle/images/icon.ico]"
 
-        theme:
-            simple:
-                     ...
-                 toolbar1: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
-                 toolbar2: "print preview media | forecolor backcolor emoticons | stfalcon | hello_world"
+            theme:
+                simple:
+                         ...
+                     toolbar1: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
+                     toolbar2: "print preview media | forecolor backcolor emoticons | stfalcon | hello_world"
 ```
 
 And you should create a callback functions `tinymce_button_` for your buttons, based on their button ID:
@@ -235,11 +241,12 @@ If you specify a relative path, it is resolved in relation to the URL of the (HT
 
 ```yaml
     stfalcon_tinymce:
-        ...
-        theme:
-            simple:
-                content_css: "asset[bundles/mybundle/css/tinymce-content.css]"
-                ...
+        tinymce_config:
+            ...
+            theme:
+                simple:
+                    content_css: "asset[bundles/mybundle/css/tinymce-content.css]"
+                    ...
 ```
 
 > NOTE! Read Official TinyMCE documentation for more details: http://www.tinymce.com/wiki.php/Configuration:content_css

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,47 +30,10 @@ class Configuration implements ConfigurationInterface
                     ->booleanNode('tinymce_jquery')->defaultFalse()->end()
                     // Set init to true to use callback on the event init
                     ->booleanNode('use_callback_tinymce_init')->defaultFalse()->end()
-                    // Selector
-                    ->scalarNode('selector')->defaultValue('.tinymce')->end()
-                    // base url for content
-                    ->scalarNode('base_url')->end()
-                    // Default language for all instances of the editor
-                    ->scalarNode('language')->defaultNull()->end()
-                    ->arrayNode('theme')
-                        ->useAttributeAsKey('name')
-                        ->prototype('array')
-                            ->useAttributeAsKey('name')
-                            ->prototype('variable')->end()
-                        ->end()
-                        // Add default theme if it doesn't set
+                    // Raw configuration for TinyMCE
+                    ->variableNode('config')
                         ->defaultValue($defaults)
                     ->end()
-                    // Configure custom TinyMCE buttons
-                    ->arrayNode('tinymce_buttons')
-                        ->useAttributeAsKey('name')
-                        ->prototype('array')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('text')->defaultNull()->end()
-                                ->scalarNode('title')->defaultNull()->end()
-                                ->scalarNode('image')->defaultNull()->end()
-                                ->scalarNode('icon')->defaultNull()->end()
-                            ->end()
-                        ->end()
-                    ->end()
-                    // Configure external TinyMCE plugins
-                    ->arrayNode('external_plugins')
-                        ->useAttributeAsKey('name')
-                        ->prototype('array')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('url')->isRequired()->end()
-                            ->end()
-                        ->end()
-                    ->end()
-                    ->scalarNode('convert_urls')->defaultNull()->end()
-                    ->scalarNode('relative_urls')->defaultNull()->end()
-                    ->scalarNode('document_base_url')->defaultNull()->end()
                 ->end()
             ->end();
     }
@@ -83,20 +46,23 @@ class Configuration implements ConfigurationInterface
     private function getTinymceDefaults()
     {
         return array(
-            'advanced' => array(
-                "theme"        => "modern",
-                "plugins"      => array(
-                    "advlist autolink lists link image charmap print preview hr anchor pagebreak",
-                    "searchreplace wordcount visualblocks visualchars code fullscreen",
-                    "insertdatetime media nonbreaking save table contextmenu directionality",
-                    "emoticons template paste textcolor"
+            'selector'  => '.tinymce',
+            'theme' => array(
+                'advanced' => array(
+                    "theme"        => "modern",
+                    "plugins"      => array(
+                        "advlist autolink lists link image charmap print preview hr anchor pagebreak",
+                        "searchreplace wordcount visualblocks visualchars code fullscreen",
+                        "insertdatetime media nonbreaking save table contextmenu directionality",
+                        "emoticons template paste textcolor"
+                    ),
+                    "toolbar1"     => "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify
+                                       | bullist numlist outdent indent | link image",
+                    "toolbar2"     => "print preview media | forecolor backcolor emoticons",
+                    "image_advtab" => true,
                 ),
-                "toolbar1"     => "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify
-                                   | bullist numlist outdent indent | link image",
-                "toolbar2"     => "print preview media | forecolor backcolor emoticons",
-                "image_advtab" => true,
+                'simple'   => array()
             ),
-            'simple'   => array()
         );
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,7 +35,26 @@ class Configuration implements ConfigurationInterface
                         ->defaultValue($defaults)
                     ->end()
                 ->end()
-            ->end();
+                ->beforeNormalization()
+                    ->ifArray()
+                    ->then(function ($config) {
+                        $default_config = $this->getTinymceDefaults();
+                        
+                        if(!isset($config['tinymce_config']['selector'])){
+                            $config['tinymce_config']['selector'] = $default_config['selector'];
+                        }
+                        
+                        if(!isset($config['tinymce_config']['theme'])){
+                            $config['tinymce_config']['theme'] = $default_config['theme'];
+                        }else{
+                            $config['tinymce_config']['theme'] = array_merge_recursive($default_config['theme'], $config['tinymce_config']['theme']);
+                        }
+                        
+                        return $config;
+                    })
+                ->end()
+            ->end()
+            ;
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
                     // Set init to true to use callback on the event init
                     ->booleanNode('use_callback_tinymce_init')->defaultFalse()->end()
                     // Raw configuration for TinyMCE
-                    ->variableNode('config')
+                    ->variableNode('tinymce_config')
                         ->defaultValue($defaults)
                     ->end()
                 ->end()

--- a/src/DependencyInjection/StfalconTinymceExtension.php
+++ b/src/DependencyInjection/StfalconTinymceExtension.php
@@ -23,12 +23,12 @@ class StfalconTinymceExtension extends Extension
         // Get default configuration of the bundle
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        if (empty($config['theme'])) {
-            $config['theme'] = array(
+        if (empty($config['config']['theme'])) {
+            $config['config']['theme'] = array(
                 'simple' => array()
             );
         } else {
-            foreach ($config['theme'] as &$bundleTheme) {
+            foreach ($config['config']['theme'] as &$bundleTheme) {
                 // Quick fix for the removed obsolete themes
                 if (isset($bundleTheme['theme']) && in_array($bundleTheme['theme'], array('advanced', 'simple'))) {
                     $bundleTheme['theme'] = 'modern';

--- a/src/DependencyInjection/StfalconTinymceExtension.php
+++ b/src/DependencyInjection/StfalconTinymceExtension.php
@@ -23,12 +23,12 @@ class StfalconTinymceExtension extends Extension
         // Get default configuration of the bundle
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        if (empty($config['config']['theme'])) {
-            $config['config']['theme'] = array(
+        if (empty($config['tinymce_config']['theme'])) {
+            $config['tinymce_config']['theme'] = array(
                 'simple' => array()
             );
         } else {
-            foreach ($config['config']['theme'] as &$bundleTheme) {
+            foreach ($config['tinymce_config']['theme'] as &$bundleTheme) {
                 // Quick fix for the removed obsolete themes
                 if (isset($bundleTheme['theme']) && in_array($bundleTheme['theme'], array('advanced', 'simple'))) {
                     $bundleTheme['theme'] = 'modern';

--- a/src/Resources/public/js/init.jquery.js
+++ b/src/Resources/public/js/init.jquery.js
@@ -63,15 +63,7 @@ function initTinyMCE(options) {
                     }
                 };
                 
-                if(typeof options.convert_urls === 'boolean'){
-                    settings.convert_urls = options.convert_urls;
-                }
-                if(typeof options.relative_urls === 'boolean'){
-                    settings.relative_urls = options.relative_urls;
-                }
-                if(typeof options.document_base_url === 'string'){
-                    settings.convert_urls = options.document_base_url;
-                }
+                $.extend(settings, options);
 
                 textarea.tinymce(settings);
             });

--- a/src/Resources/public/js/init.standard.js
+++ b/src/Resources/public/js/init.standard.js
@@ -4,7 +4,6 @@
  * @param options
  */
 function initTinyMCE(options) {
-    console.log(options, stfalcon_tinymce_config);
     if (typeof tinymce == 'undefined') return false;
     if (typeof options == 'undefined') options = stfalcon_tinymce_config;
     // Load when DOM is ready

--- a/src/Resources/public/js/init.standard.js
+++ b/src/Resources/public/js/init.standard.js
@@ -4,6 +4,7 @@
  * @param options
  */
 function initTinyMCE(options) {
+    console.log(options, stfalcon_tinymce_config);
     if (typeof tinymce == 'undefined') return false;
     if (typeof options == 'undefined') options = stfalcon_tinymce_config;
     // Load when DOM is ready
@@ -99,15 +100,11 @@ function initTinyMCE(options) {
                 }
             }
             
-            if(typeof options.convert_urls === 'boolean'){
-                settings.convert_urls = options.convert_urls;
-            }
-            if(typeof options.relative_urls === 'boolean'){
-                settings.relative_urls = options.relative_urls;
-            }
-            if(typeof options.document_base_url === 'string'){
-                settings.convert_urls = options.document_base_url;
-            }
+            Object.keys(options).forEach(function(val){
+                if(typeof settings === 'undefined'){
+                    settings[val] = options[val];
+                }
+            });
             
             // Initialize textarea by its ID attribute
             tinymce

--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -87,35 +87,39 @@ class StfalconTinymceExtension extends \Twig_Extension
             $config = array_merge_recursive($config, $options);
         }
         
-        $tinyMCE_config = $options['tinymce_config'];
+        $tinyMCE_config = $config['tinymce_config'];
 
         $this->baseUrl = (!isset($tinyMCE_config['base_url']) ? null : $tinyMCE_config['base_url']);
 
         // Get path to tinymce script for the jQuery version of the editor
-        if ($tinyMCE_config['tinymce_jquery']) {
-            $tinyMCE_config['jquery_script_url'] = $this->getUrl(
+        if ($config['tinymce_jquery']) {
+            $config['jquery_script_url'] = $this->getUrl(
                 $this->baseUrl . 'bundles/stfalcontinymce/vendor/tinymce/tinymce.jquery.min.js'
             );
         }
 
         // Get local button's image
-        foreach ($tinyMCE_config['tinymce_buttons'] as &$customButton) {
-            if ($customButton['image']) {
-                $customButton['image'] = $this->getAssetsUrl($customButton['image']);
-            } else {
-                unset($customButton['image']);
-            }
+        if(isset($tinyMCE_config['tinymce_buttons']) && is_array($tinyMCE_config['tinymce_buttons'])){
+            foreach ($tinyMCE_config['tinymce_buttons'] as &$customButton) {
+                if ($customButton['image']) {
+                    $customButton['image'] = $this->getAssetsUrl($customButton['image']);
+                } else {
+                    unset($customButton['image']);
+                }
 
-            if ($customButton['icon']) {
-                $customButton['icon'] = $this->getAssetsUrl($customButton['icon']);
-            } else {
-                unset($customButton['icon']);
+                if ($customButton['icon']) {
+                    $customButton['icon'] = $this->getAssetsUrl($customButton['icon']);
+                } else {
+                    unset($customButton['icon']);
+                }
             }
         }
-
+        
         // Update URL to external plugins
-        foreach ($tinyMCE_config['external_plugins'] as &$extPlugin) {
-            $extPlugin['url'] = $this->getAssetsUrl($extPlugin['url']);
+        if(isset($tinyMCE_config['external_plugins']) && is_array($tinyMCE_config['external_plugins'])){
+            foreach ($tinyMCE_config['external_plugins'] as &$extPlugin) {
+                $extPlugin['url'] = $this->getAssetsUrl($extPlugin['url']);
+            }
         }
 
         // If the language is not set in the config...

--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -86,18 +86,20 @@ class StfalconTinymceExtension extends \Twig_Extension
         } else {
             $config = array_merge_recursive($config, $options);
         }
+        
+        $tinyMCE_config = $options['tinymce_config'];
 
-        $this->baseUrl = (!isset($config['base_url']) ? null : $config['base_url']);
+        $this->baseUrl = (!isset($tinyMCE_config['base_url']) ? null : $tinyMCE_config['base_url']);
 
         // Get path to tinymce script for the jQuery version of the editor
-        if ($config['tinymce_jquery']) {
-            $config['jquery_script_url'] = $this->getUrl(
+        if ($tinyMCE_config['tinymce_jquery']) {
+            $tinyMCE_config['jquery_script_url'] = $this->getUrl(
                 $this->baseUrl . 'bundles/stfalcontinymce/vendor/tinymce/tinymce.jquery.min.js'
             );
         }
 
         // Get local button's image
-        foreach ($config['tinymce_buttons'] as &$customButton) {
+        foreach ($tinyMCE_config['tinymce_buttons'] as &$customButton) {
             if ($customButton['image']) {
                 $customButton['image'] = $this->getAssetsUrl($customButton['image']);
             } else {
@@ -112,12 +114,12 @@ class StfalconTinymceExtension extends \Twig_Extension
         }
 
         // Update URL to external plugins
-        foreach ($config['external_plugins'] as &$extPlugin) {
+        foreach ($tinyMCE_config['external_plugins'] as &$extPlugin) {
             $extPlugin['url'] = $this->getAssetsUrl($extPlugin['url']);
         }
 
         // If the language is not set in the config...
-        if (!isset($config['language']) || empty($config['language'])) {
+        if (!isset($tinyMCE_config['language']) || empty($tinyMCE_config['language'])) {
             // get it from the request
             if ($this->container->has('request_stack')) {
                 $request = $this->getService('request_stack')->getCurrentRequest();
@@ -125,35 +127,35 @@ class StfalconTinymceExtension extends \Twig_Extension
                 $request = $this->getService('request');
             }
             if ($request) {
-                $config['language'] = $request->getLocale();
+                $tinyMCE_config['language'] = $request->getLocale();
             }
         }
 
-        $config['language'] = LocaleHelper::getLanguage($config['language']);
+        $tinyMCE_config['language'] = LocaleHelper::getLanguage($tinyMCE_config['language']);
 
 	    $langDirectory = __DIR__ . '/../../Resources/public/vendor/tinymce-langs/';
 
         // A language code coming from the locale may not match an existing language file
-        if (!file_exists($langDirectory . $config['language'] . '.js')) {
-            unset($config['language']);
+        if (!file_exists($langDirectory . $tinyMCE_config['language'] . '.js')) {
+            unset($tinyMCE_config['language']);
         }
 
-        if (isset($config['language']) && $config['language']) {
+        if (isset($tinyMCE_config['language']) && $tinyMCE_config['language']) {
             $languageUrl = $this->getUrl(
-                $this->baseUrl.'bundles/stfalcontinymce/vendor/tinymce-langs/'.$config['language'].'.js'
+                $this->baseUrl.'bundles/stfalcontinymce/vendor/tinymce-langs/'.$tinyMCE_config['language'].'.js'
             );
             // TinyMCE does not allow to set different languages to each instance
-            foreach ($config['theme'] as $themeName => $themeOptions) {
-                $config['theme'][$themeName]['language'] = $config['language'];
-                $config['theme'][$themeName]['language_url'] = $languageUrl;
+            foreach ($tinyMCE_config['theme'] as $themeName => $themeOptions) {
+                $tinyMCE_config['theme'][$themeName]['language'] = $tinyMCE_config['language'];
+                $tinyMCE_config['theme'][$themeName]['language_url'] = $languageUrl;
             }
-            $config['language_url'] = $languageUrl;
+            $tinyMCE_config['language_url'] = $languageUrl;
         }
 
-        if (isset($config['theme']) && $config['theme'])
+        if (isset($tinyMCE_config['theme']) && $tinyMCE_config['theme'])
         {
             // Parse the content_css of each theme so we can use 'asset[path/to/asset]' in there
-            foreach ($config['theme'] as $themeName => $themeOptions) {
+            foreach ($tinyMCE_config['theme'] as $themeName => $themeOptions) {
                 if(isset($themeOptions['content_css']))
                 {
                     // As there may be multiple CSS Files specified we need to parse each of them individually
@@ -165,7 +167,7 @@ class StfalconTinymceExtension extends \Twig_Extension
                     }
 
                     // After parsing we add them together again.
-                    $config['theme'][$themeName]['content_css'] = implode(',', $cssFiles);
+                    $tinyMCE_config['theme'][$themeName]['content_css'] = implode(',', $cssFiles);
                 }
             }
         }
@@ -173,7 +175,7 @@ class StfalconTinymceExtension extends \Twig_Extension
         return $this->getService('templating')->render('StfalconTinymceBundle:Script:init.html.twig', array(
             'tinymce_config' => preg_replace(
                 '/"file_browser_callback":"([^"]+)"\s*/', 'file_browser_callback:$1',
-                json_encode($config)
+                json_encode($tinyMCE_config)
             ),
             'include_jquery' => $config['include_jquery'],
             'tinymce_jquery' => $config['tinymce_jquery'],


### PR DESCRIPTION
I'm starting to work on #19 realize that some questions need to be discussed.
- do we keep the compatibility with current configuration version ?
- the 3 options `include_jquery` `tinymce_jquery` and `use_callback_tinymce_init` are not TinyMCE config options, but there are mixed with it in `tinymce_init()` Twig function. How do we handle that ?

From a general point of view : do we keep a full compatibility with the current implementation ? Or we accept some BC break to keep the implementation more light ?
