### PR TITLE
Update type hint to use the proper event class

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -2,7 +2,7 @@
 
 namespace Stfalcon\Bundle\TinymceBundle\Composer;
 
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseScriptHandler;
 
 /**
@@ -15,7 +15,7 @@ class ScriptHandler extends BaseScriptHandler
     /**
      * @param \Composer\Script\CommandEvent $event
      */
-    public static function createSymlink(CommandEvent $event)
+    public static function createSymlink(Event $event)
     {
         $options = self::getOptions($event);
         $consoleDir = self::getConsoleDir($event, 'hello world');

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -13,7 +13,7 @@ use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseScriptHandler
 class ScriptHandler extends BaseScriptHandler
 {
     /**
-     * @param \Composer\Script\CommandEvent $event
+     * @param Event $event
      */
     public static function createSymlink(Event $event)
     {


### PR DESCRIPTION
As explained in sensiolabs/SensioDistributionBundle#265:

> Deprecation Notice: The callback Stfalcon\Bundle\TinymceBundle\Composer\ScriptHandler::createSymlink declared at vendor/gibilogic/tinymce-bundle/src/Composer/ScriptHandler.php accepts a Composer\Script\CommandEvent but post-update-cmd events use a Composer\Script\Event instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes
