### PR TITLE
Fix merging process form theme configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -54,7 +54,8 @@ class Configuration implements ConfigurationInterface
      * @param array $config
      * @return array
      */
-    private function validateTinymceConfig($config){
+    private function validateTinymceConfig($config)
+    {
         $default_config = $this->getTinymceDefaults();
         
         if(!isset($config['selector'])){
@@ -65,6 +66,7 @@ class Configuration implements ConfigurationInterface
         }else{
             $config['theme'] = array_merge_recursive($default_config['theme'], $config['theme']);
         }
+        
         return $config;
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,10 @@ class Configuration implements ConfigurationInterface
     {
         $defaults = $this->getTinymceDefaults();
 
+        $validatorClosure = function($config){
+            return $this->validateTinymceConfig($config);
+        };
+        
         $treeBuilder = new TreeBuilder();
 
         return $treeBuilder
@@ -33,29 +37,37 @@ class Configuration implements ConfigurationInterface
                     // Raw configuration for TinyMCE
                     ->variableNode('tinymce_config')
                         ->defaultValue($defaults)
+                        ->validate()
+                        ->always()
+                            ->then($validatorClosure->bindTo($this))
+                        ->end()
                     ->end()
-                ->end()
-                ->beforeNormalization()
-                    ->ifArray()
-                    ->then(function ($config) {
-                        $default_config = $this->getTinymceDefaults();
-                        
-                        if(!isset($config['tinymce_config']['selector'])){
-                            $config['tinymce_config']['selector'] = $default_config['selector'];
-                        }
-                        
-                        if(!isset($config['tinymce_config']['theme'])){
-                            $config['tinymce_config']['theme'] = $default_config['theme'];
-                        }else{
-                            $config['tinymce_config']['theme'] = array_merge_recursive($default_config['theme'], $config['tinymce_config']['theme']);
-                        }
-                        
-                        return $config;
-                    })
                 ->end()
             ->end()
             ;
+        
     }
+    
+    /**
+     * Validate TinyMCE config and ensure that necessary default values are set
+     * 
+     * @param array $config
+     * @return array
+     */
+    private function validateTinymceConfig($config){
+        $default_config = $this->getTinymceDefaults();
+        
+        if(!isset($config['selector'])){
+            $config['selector'] = $default_config['selector'];
+        }
+        if(!isset($config['theme'])){
+            $config['theme'] = $default_config['theme'];
+        }else{
+            $config['theme'] = array_merge_recursive($default_config['theme'], $config['theme']);
+        }
+        return $config;
+    }
+
 
     /**
      * Get default configuration of the each instance of editor

--- a/src/Resources/public/js/init.jquery.js
+++ b/src/Resources/public/js/init.jquery.js
@@ -21,7 +21,9 @@ function initTinyMCE(options) {
                 $.extend(settings, (typeof options.theme[theme] != 'undefined')
                     ? options.theme[theme]
                     : options.theme['simple'], options);
+                delete settings.theme;
 
+                settings.script_url = options.jquery_script_url;
                 settings.external_plugins = settings.external_plugins || {};
                 // workaround for an incompatibility with html5-validation
                 if (textarea.prop('required')) {

--- a/src/Resources/public/js/init.jquery.js
+++ b/src/Resources/public/js/init.jquery.js
@@ -17,16 +17,17 @@ function initTinyMCE(options) {
                     theme = textarea.attr('data-theme') || 'simple';
 
                 // Get selected theme options
-                var settings = (typeof options.theme[theme] != 'undefined')
+                var settings = {};
+                $.extend(settings, (typeof options.theme[theme] != 'undefined')
                     ? options.theme[theme]
-                    : options.theme['simple'];
+                    : options.theme['simple'], options);
 
-                settings.script_url = options.jquery_script_url;
                 settings.external_plugins = settings.external_plugins || {};
                 // workaround for an incompatibility with html5-validation
-                if (textarea.is('[required]')) {
+                if (textarea.prop('required')) {
                     textarea.prop('required', false);
                 }
+                
                 settings.setup = function(ed) {
                     // Add custom buttons to current editor
                     $.each(options.tinymce_buttons || {}, function(id, opts) {
@@ -63,8 +64,6 @@ function initTinyMCE(options) {
                     }
                 };
                 
-                $.extend(settings, options);
-
                 textarea.tinymce(settings);
             });
         });

--- a/src/Resources/public/js/init.standard.js
+++ b/src/Resources/public/js/init.standard.js
@@ -67,6 +67,7 @@ function initTinyMCE(options) {
                 : options.theme['simple']);
                 
             settings = extend(settings, options);
+            delete settings.theme;
                 
             settings.external_plugins = settings.external_plugins || {};
             for (var p = 0; p < externalPlugins.length; p++) {

--- a/src/Resources/public/js/init.standard.js
+++ b/src/Resources/public/js/init.standard.js
@@ -55,7 +55,7 @@ function initTinyMCE(options) {
                 }
             }
             return destination;
-        }
+        };
         
         for (i = 0; i < textareas.length; i++) {
             
@@ -67,7 +67,6 @@ function initTinyMCE(options) {
                 : options.theme['simple']);
                 
             settings = extend(settings, options);
-            delete settings.theme;
                 
             settings.external_plugins = settings.external_plugins || {};
             for (var p = 0; p < externalPlugins.length; p++) {
@@ -75,7 +74,7 @@ function initTinyMCE(options) {
             }
             // workaround for an incompatibility with html5-validation
             if (textareas[i].getAttribute("required") !== '') {
-                textareas[i].removeAttribute("required")
+                textareas[i].removeAttribute("required");
             }
             if (textareas[i].getAttribute('id') === '') {
                 textareas[i].setAttribute("id", "tinymce_" + Math.random().toString(36).substr(2));

--- a/src/Resources/public/js/init.standard.js
+++ b/src/Resources/public/js/init.standard.js
@@ -45,15 +45,30 @@ function initTinyMCE(options) {
                 }
             }
         }
-
+        
+        var extend = function(destination, source){
+            for (var property in source){
+                if(typeof source[property] === 'object'){
+                    destination[property] = extend(destination[property]||{}, source[property]);
+                }else{
+                    destination[property] = source[property];
+                }
+            }
+            return destination;
+        }
+        
         for (i = 0; i < textareas.length; i++) {
+            
             // Get editor's theme from the textarea data
             var theme = textareas[i].getAttribute("data-theme") || 'simple';
             // Get selected theme options
-            var settings = (typeof options.theme[theme] != 'undefined')
+            var settings = extend({}, (typeof options.theme[theme] != 'undefined')
                 ? options.theme[theme]
-                : options.theme['simple'];
-
+                : options.theme['simple']);
+                
+            settings = extend(settings, options);
+            delete settings.theme;
+                
             settings.external_plugins = settings.external_plugins || {};
             for (var p = 0; p < externalPlugins.length; p++) {
                 settings.external_plugins[externalPlugins[p]['id']] = externalPlugins[p]['url'];
@@ -65,6 +80,8 @@ function initTinyMCE(options) {
             if (textareas[i].getAttribute('id') === '') {
                 textareas[i].setAttribute("id", "tinymce_" + Math.random().toString(36).substr(2));
             }
+            settings.selector = '#'+textareas[i].getAttribute('id');
+            
             // Add custom buttons to current editor
             if (typeof options.tinymce_buttons == 'object') {
                 settings.setup = function(editor) {
@@ -98,17 +115,8 @@ function initTinyMCE(options) {
                     }
                 }
             }
-            
-            Object.keys(options).forEach(function(val){
-                if(typeof settings === 'undefined'){
-                    settings[val] = options[val];
-                }
-            });
-            
-            // Initialize textarea by its ID attribute
-            tinymce
-                .createEditor(textareas[i].getAttribute('id'), settings)
-                .render();
+
+            tinymce.init(settings);
         }
     });
 }

--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -93,7 +93,7 @@ class StfalconTinymceExtension extends \Twig_Extension
 
         // Get path to tinymce script for the jQuery version of the editor
         if ($config['tinymce_jquery']) {
-            $config['jquery_script_url'] = $this->getUrl(
+            $tinyMCE_config['jquery_script_url'] = $this->getUrl(
                 $this->baseUrl . 'bundles/stfalcontinymce/vendor/tinymce/tinymce.jquery.min.js'
             );
         }


### PR DESCRIPTION
Since the lasts changes with the introduction of the `tinymce_config` parameter it was not possible to overwrite a sub-part of the `theme` parameters.

Relying on the normalization to define the default mandatory parameters was breaking the merging process when using with prepend configuration (for example, overwriting the toolbar parameter of the simple theme was producing an empty configuration). Secondly, the merging of this parameter in javascript was failing as well.

This PR define the default configuration for TinyMCE at validation time (after the merging process) and fix the merging process in javascript by using a similar $.extend() function in bare JS.

As always, this changes are tested successfully from sf2.3 to 2.8, with and without jQuery. 
I hope that you can review that quickly and add a new tag as it's blocking for me. Thanks in advance.
