### PR TITLE
Pass use_callback_tinymce_init to tinyMCE_config

### DIFF
--- a/src/Twig/Extension/StfalconTinymceExtension.php
+++ b/src/Twig/Extension/StfalconTinymceExtension.php
@@ -86,8 +86,9 @@ class StfalconTinymceExtension extends \Twig_Extension
         } else {
             $config = array_merge_recursive($config, $options);
         }
-        
+
         $tinyMCE_config = $config['tinymce_config'];
+        $tinyMCE_config['use_callback_tinymce_init'] = $config['use_callback_tinymce_init'];
 
         $this->baseUrl = (!isset($tinyMCE_config['base_url']) ? null : $tinyMCE_config['base_url']);
 


### PR DESCRIPTION
As of 1.3.x the config option ``use_callback_tinymce_init`` is no longer passed to the view config, so ``options.use_callback_tinymce_init`` in src/Resources/public/js/init.(jquery|standard).js is always undefined. This PR fixes this.